### PR TITLE
Update config to framework 14

### DIFF
--- a/.env
+++ b/.env
@@ -44,7 +44,7 @@ MAILER_DEFAULT_TO_EMAIL="mailer_default_to_email_is_misconfigured@tesuta.be"
 # Choose one of the transports below
 # MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
 # MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
-MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
+MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=1
 ###< symfony/messenger ###
 
 ###> sumocoders/framework-core-bundle ###

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,6 @@ Install dependencies and build assets:
     - COMPOSER_MEMORY_LIMIT=-1 composer run-script post-autoload-dump
     - php bin/console importmap:install --no-interaction
     - php bin/console sass:build --no-interaction
-    - php bin/console fos:js-routing:dump --format=json --locale=nl --target=public/build/routes/fos_js_routes.json
   cache:
     <<: *global_cache
     policy: pull-push
@@ -170,7 +169,7 @@ PHP packages - composer outdated:
 PHPUnit - Run tests:
   image: sumocoders/framework-php84:latest
   services:
-    - mysql:5.7
+    - mysql:8.0
   before_script:
 # Uncomment this if you need Chrome for PDF's
 # or if you have integration tests that use Symfony Panther (https://github.com/symfony/panther)

--- a/bin/console
+++ b/bin/console
@@ -3,41 +3,19 @@
 
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\ErrorHandler\Debug;
 
-if (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
-    echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
+if (!is_dir(dirname(__DIR__).'/vendor')) {
+    throw new LogicException('Dependencies are missing. Try running "composer install".');
 }
 
-set_time_limit(0);
-
-require dirname(__DIR__).'/vendor/autoload.php';
-
-if (!class_exists(Application::class) || !class_exists(Dotenv::class)) {
-    throw new LogicException('You need to add "symfony/framework-bundle" and "symfony/dotenv" as Composer dependencies.');
+if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
+    throw new LogicException('Symfony Runtime is missing. Try running "composer require symfony/runtime".');
 }
 
-$input = new ArgvInput();
-if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
-    putenv('APP_ENV='.$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
-}
+require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
-if ($input->hasParameterOption('--no-debug', true)) {
-    putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
-}
+return function (array $context) {
+    $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 
-(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
-
-if ($_SERVER['APP_DEBUG']) {
-    umask(0000);
-
-    if (class_exists(Debug::class)) {
-        Debug::enable();
-    }
-}
-
-$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
-$application = new Application($kernel);
-$application->run($input);
+    return new Application($kernel);
+};

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -3,6 +3,7 @@
 return [
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
+    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
     Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     Sentry\SentryBundle\SentryBundle::class => ['prod' => true],
@@ -11,6 +12,7 @@ return [
     Symfony\UX\TogglePassword\TogglePasswordBundle::class => ['all' => true],
     Symfony\UX\Autocomplete\AutocompleteBundle::class => ['all' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
+    Nelmio\SecurityBundle\NelmioSecurityBundle::class => ['all' => true],
     Knp\Bundle\MenuBundle\KnpMenuBundle::class => ['all' => true],
     SumoCoders\FrameworkCoreBundle\SumoCodersFrameworkCoreBundle::class => ['all' => true],
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
@@ -20,6 +22,4 @@ return [
     Symfony\UX\StimulusBundle\StimulusBundle::class => ['all' => true],
     Symfony\UX\Turbo\TurboBundle::class => ['all' => true],
     Symfonycasts\SassBundle\SymfonycastsSassBundle::class => ['all' => true],
-    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
-    Nelmio\SecurityBundle\NelmioSecurityBundle::class => ['all' => true],
 ];

--- a/config/packages/mailer.yaml
+++ b/config/packages/mailer.yaml
@@ -1,3 +1,13 @@
 framework:
     mailer:
         dsn: '%env(MAILER_DSN)%'
+
+when@dev:
+    framework:
+        mailer:
+            envelope:
+                # needs at least one recipient, otherwise allowed_recipients is ignored
+                recipients: ['mail@localhost']
+                allowed_recipients:
+                    - '.*@sumocoders.be'
+                    - '.*@tesuta.be'

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,17 +1,26 @@
 framework:
     messenger:
         # Uncomment this (and the failed transport below) to send failed messages to this transport for later handling.
-        # failure_transport: failed
+        failure_transport: failed
 
         transports:
             # https://symfony.com/doc/current/messenger.html#transport-configuration
-            # async: '%env(MESSENGER_TRANSPORT_DSN)%'
-            # failed: 'doctrine://default?queue_name=failed'
+            async:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                retry_strategy:
+                    max_retries: 0
+            failed: 'doctrine://default?queue_name=failed'
             # sync: 'sync://'
 
         routing:
             # Route your messages to the transports
             # 'App\Message\YourMessage': async
+
+when@prod:
+    framework:
+        messenger:
+            routing:
+                'Symfony\Component\Mailer\Messenger\SendEmailMessage': async
 
 # when@test:
 #    framework:

--- a/config/packages/symfonycasts_sass.yaml
+++ b/config/packages/symfonycasts_sass.yaml
@@ -1,4 +1,3 @@
-
 symfonycasts_sass:
   root_sass:
     - '%kernel.project_dir%/assets/styles/style.scss'

--- a/config/packages/ux_turbo.yaml
+++ b/config/packages/ux_turbo.yaml
@@ -1,0 +1,4 @@
+# Enable stateless CSRF protection for forms and logins/logouts
+framework:
+    csrf_protection:
+        check_header: true

--- a/config/packages/web_profiler.yaml
+++ b/config/packages/web_profiler.yaml
@@ -8,4 +8,6 @@ when@dev:
 
 when@test:
     framework:
-        profiler: { collect: false }
+        profiler:
+            collect: false
+            collect_serializer_data: true

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -3,5 +3,7 @@ controllers:
         path: ../src/Controller/
         namespace: App\Controller
     type: attribute
-    prefix:
-        nl: ''
+    prefix: /{_locale}
+    requirements:
+       _locale: '%locales_regex%'
+    trailing_slash_on_root: false

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -3,36 +3,9 @@
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
-use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
-
-    protected function configureContainer(ContainerConfigurator $container): void
-    {
-        $container->import('../config/{packages}/*.yaml');
-        $container->import('../config/{packages}/' . $this->environment . '/*.yaml');
-
-        if (is_file(\dirname(__DIR__) . '/config/services.yaml')) {
-            $container->import('../config/services.yaml');
-            $container->import('../config/{services}_' . $this->environment . '.yaml');
-        } elseif (is_file($path = \dirname(__DIR__) . '/config/services.php')) {
-            (require $path)($container->withPath($path), $this);
-        }
-    }
-
-    protected function configureRoutes(RoutingConfigurator $routes): void
-    {
-        $routes->import('../config/{routes}/' . $this->environment . '/*.yaml');
-        $routes->import('../config/{routes}/*.yaml');
-
-        if (is_file(\dirname(__DIR__) . '/config/routes.yaml')) {
-            $routes->import('../config/routes.yaml');
-        } elseif (is_file($path = \dirname(__DIR__) . '/config/routes.php')) {
-            (require $path)($routes->withPath($path), $this);
-        }
-    }
 }


### PR DESCRIPTION
## Summary by Sourcery

Update project configuration to align with Framework 14 defaults and best practices, removing legacy Kernel methods and refining service and routing settings.

New Features:
- Add DAMA\DoctrineTestBundle for tests environment
- Add Nelmio\SecurityBundle globally
- Enable stateless CSRF header checks for forms and logins/logouts via ux_turbo configuration
- Introduce locale-aware route prefixes with requirement enforcement

Enhancements:
- Remove custom configureContainer and configureRoutes methods from Kernel to rely on default behavior
- Restructure messenger configuration: enable failure transport, define transports with retry strategy, and add production routing for SendEmailMessage
- Add development envelope recipient restrictions and allowed patterns to mailer configuration
- Enable serializer data collection in the web profiler for tests
- Clean up symfonycasts_sass configuration file

CI:
- Bump MySQL service from 5.7 to 8.0 in GitLab CI
- Remove deprecated fos:js-routing dump step

Chores:
- Add and remove bundle registrations for DAMA\DoctrineTestBundle and NelmioSecurityBundle in bundles.php