### PR TITLE
(feat) Pass the locale

### DIFF
--- a/src/Command/User/CreateCommand.php
+++ b/src/Command/User/CreateCommand.php
@@ -28,7 +28,7 @@ class CreateCommand extends Command
     public function __invoke(
         SymfonyStyle $io,
         #[Argument(description: 'The email of the user')] string $email,
-        #[Argument(description: 'The locale to use')] string $locale = 'en',
+        #[Argument(description: 'The locale to use')] string $locale = 'nl',
         #[Argument(description: 'The roles of the user')] array $roles = ['ROLE_USER'],
     ): int {
         $message = new CreateUser();

--- a/src/Command/User/CreateCommand.php
+++ b/src/Command/User/CreateCommand.php
@@ -25,10 +25,12 @@ class CreateCommand extends Command
     public function __invoke(
         SymfonyStyle $io,
         #[Argument(description: 'The email of the user')] string $email,
+        #[Argument(description: 'The locale to use')] string $locale = 'en',
         #[Argument(description: 'The roles of the user')] array $roles = ['ROLE_USER'],
     ): int {
         $message = new CreateUser();
         $message->email = $email;
+        $message->locale = $locale;
         $message->roles = $roles;
 
         $constraints = $this->validator->validate($message);

--- a/src/Command/User/CreateCommand.php
+++ b/src/Command/User/CreateCommand.php
@@ -22,6 +22,9 @@ class CreateCommand extends Command
         parent::__construct();
     }
 
+    /**
+     * @param array<string> $roles
+     */
     public function __invoke(
         SymfonyStyle $io,
         #[Argument(description: 'The email of the user')] string $email,

--- a/src/Controller/User/Admin/AddUserController.php
+++ b/src/Controller/User/Admin/AddUserController.php
@@ -29,8 +29,8 @@ class AddUserController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            /** @var CreateUser $message */
             $message = $form->getData();
-            // @phpstan-ignore-next-line property.notFound
             $message->locale = $request->getLocale();
             $this->messageBus->dispatch($message);
 

--- a/src/Controller/User/Admin/AddUserController.php
+++ b/src/Controller/User/Admin/AddUserController.php
@@ -30,6 +30,7 @@ class AddUserController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $message = $form->getData();
+            // @phpstan-ignore-next-line property.notFound
             $message->locale = $request->getLocale();
             $this->messageBus->dispatch($message);
 

--- a/src/Controller/User/Admin/AddUserController.php
+++ b/src/Controller/User/Admin/AddUserController.php
@@ -29,7 +29,9 @@ class AddUserController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->messageBus->dispatch($form->getData());
+            $message = $form->getData();
+            $message->locale = $request->getLocale();
+            $this->messageBus->dispatch($message);
 
             $this->addFlash(
                 'success',

--- a/src/Controller/User/Admin/RequestConfirmationController.php
+++ b/src/Controller/User/Admin/RequestConfirmationController.php
@@ -5,6 +5,7 @@ namespace App\Controller\User\Admin;
 use App\Entity\User\User;
 use App\Message\User\SendConfirmation;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
@@ -19,7 +20,7 @@ class RequestConfirmationController extends AbstractController
     ) {
     }
 
-    public function __invoke(User $user): Response
+    public function __invoke(User $user, Request $request): Response
     {
         if ($user->isConfirmed()) {
             $this->addFlash(
@@ -30,7 +31,7 @@ class RequestConfirmationController extends AbstractController
             return $this->redirectToRoute('user_admin_edit', ['user' => $user->getId()]);
         }
 
-        $this->messageBus->dispatch(new SendConfirmation($user));
+        $this->messageBus->dispatch(new SendConfirmation($user, $request->getLocale()));
 
         $this->addFlash(
             'success',

--- a/src/Controller/User/ResendConfirmationController.php
+++ b/src/Controller/User/ResendConfirmationController.php
@@ -21,7 +21,7 @@ final class ResendConfirmationController extends AbstractController
     ) {
     }
 
-    public function __invoke(string $token): Response
+    public function __invoke(string $token, Request $request): Response
     {
         $user = $this->userRepository->findOneBy(['confirmationToken' => $token]);
 
@@ -34,7 +34,7 @@ final class ResendConfirmationController extends AbstractController
             return $this->redirectToRoute('login');
         }
 
-        $this->messageBus->dispatch(new SendConfirmation($user));
+        $this->messageBus->dispatch(new SendConfirmation($user, $request->getLocale()));
 
         $this->addFlash('success', $this->translator->trans('Confirmation mail successfully resent'));
 

--- a/src/Controller/User/ResendConfirmationController.php
+++ b/src/Controller/User/ResendConfirmationController.php
@@ -6,6 +6,7 @@ use App\Entity\User\User;
 use App\Message\User\SendConfirmation;
 use App\Repository\User\UserRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;

--- a/src/DataTransferObject/User/UserDataTransferObject.php
+++ b/src/DataTransferObject/User/UserDataTransferObject.php
@@ -19,4 +19,6 @@ class UserDataTransferObject
      * @var array<int, string> $roles
      */
     public array $roles = [];
+
+    public string $locale;
 }

--- a/src/Message/User/SendConfirmation.php
+++ b/src/Message/User/SendConfirmation.php
@@ -7,7 +7,8 @@ use App\Entity\User\User;
 class SendConfirmation
 {
     public function __construct(
-        public readonly User $user
+        public readonly User $user,
+        public readonly string $locale
     ) {
     }
 }

--- a/src/MessageHandler/User/CreateUserHandler.php
+++ b/src/MessageHandler/User/CreateUserHandler.php
@@ -26,7 +26,7 @@ final class CreateUserHandler
         );
         $user->requestPassword();
         $this->userRepository->add($user);
-        $this->messageBus->dispatch(new SendConfirmation($user));
+        $this->messageBus->dispatch(new SendConfirmation($user, $message->locale));
 
         return $user;
     }

--- a/src/MessageHandler/User/RegisterUserHandler.php
+++ b/src/MessageHandler/User/RegisterUserHandler.php
@@ -30,6 +30,6 @@ final class RegisterUserHandler
         $encodedPassword = $this->passwordEncoder->hashPassword($user, $message->password);
         $user->setPassword($encodedPassword);
         $this->userRepository->add($user);
-        $this->messageBus->dispatch(new SendConfirmation($user));
+        $this->messageBus->dispatch(new SendConfirmation($user, $message->locale));
     }
 }

--- a/src/MessageHandler/User/SendConfirmationHandler.php
+++ b/src/MessageHandler/User/SendConfirmationHandler.php
@@ -45,6 +45,7 @@ class SendConfirmationHandler
                 'confirmationLink' => $this->router->generate(
                     'user_confirm',
                     [
+                        '_locale' => $message->locale,
                         'token' => $user->getConfirmationToken(),
                     ],
                     RouterInterface::ABSOLUTE_URL


### PR DESCRIPTION
Pass the locale in the `app:user:create` console command. 
With this the email can be send.

## Summary by Sourcery

Pass the user's locale throughout account creation and confirmation flows to enable sending localized confirmation emails.

New Features:
- Add an optional locale argument to the `app:user:create` console command and include it in the CreateUser message.
- Propagate HTTP request locale from AddUser, RequestConfirmation, and ResendConfirmation controllers into the SendConfirmation message.
- Extend SendConfirmation message, UserDataTransferObject, and message handlers to carry locale and generate confirmation links with the correct locale.

Enhancements:
- Update SendConfirmationHandler to include the locale when generating the confirmation URL.