### PR TITLE
fix(users) Make search in user overview work

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -10,6 +10,9 @@ use Symfony\Component\Routing\Attribute\Route;
 
 class HomeController extends AbstractController
 {
+    /**
+     * @param string[] $locales
+     */
     #[Route('/', name: 'home', defaults: ['_locale' => 'nl'])]
     public function __invoke(
         Request $request,

--- a/src/Form/User/Admin/FilterType.php
+++ b/src/Form/User/Admin/FilterType.php
@@ -16,6 +16,7 @@ class FilterType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
+            ->setMethod('GET')
             ->add(
                 'term',
                 TextType::class,
@@ -28,6 +29,8 @@ class FilterType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setDefault('data_class', FilterDataTransferObject::class);
+        $resolver
+            ->setDefault('data_class', FilterDataTransferObject::class)
+            ->setDefault('csrf_protection', false);
     }
 }


### PR DESCRIPTION
Switching to GET also makes sure we can link to a filtered overview

## Summary by Sourcery

Enable deep-linking to filtered user overview by updating the filter form to use GET requests and disabling CSRF protection

Bug Fixes:
- Restore search functionality in user overview by switching the filter form to GET

Enhancements:
- Disable CSRF protection on the user filter form to support GET requests