### PR TITLE
deprecation: fix deprecation for checkPostAuth

### DIFF
--- a/src/Security/UserChecker.php
+++ b/src/Security/UserChecker.php
@@ -6,6 +6,7 @@ use App\Entity\User\User;
 use App\Repository\User\UserRepository;
 use App\Security\Exception\UnconfirmedAccountException;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -47,7 +48,7 @@ final class UserChecker implements UserCheckerInterface
         }
     }
 
-    public function checkPostAuth(UserInterface $user): void
+    public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void
     {
         if (!$user instanceof User) {
             return;


### PR DESCRIPTION
> The "App\Security\UserChecker::checkPostAuth()" method will require a new "?TokenInterface $token" argument in the next major version of its interface "Symfony\Component\Security\Core\User\UserCheckerInterface", not defining it is deprecated.

## Summary by Sourcery

Bug Fixes:
- Fix deprecation warning by updating checkPostAuth signature to include optional TokenInterface parameter