### PR TITLE
fix: make term nullable

### DIFF
--- a/src/DataTransferObject/User/FilterDataTransferObject.php
+++ b/src/DataTransferObject/User/FilterDataTransferObject.php
@@ -4,5 +4,5 @@ namespace App\DataTransferObject\User;
 
 class FilterDataTransferObject
 {
-    public string $term;
+    public ?string $term = null;
 }


### PR DESCRIPTION
Changed `public string $term;` to `public ?string $term = null;` in `FilterDataTransferObject`

## Summary by Sourcery

Bug Fixes:
- Prevent errors when no term is provided to FilterDataTransferObject by allowing the term property to be null.